### PR TITLE
PDFs doesn't start with %PDF-xxx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ WORKDIR /home/converter
 # Write stdin to 'input_file'
 CMD cat - > input_file \
     # Convert 'input_file' to pdf
-    && libreoffice --invisible --headless --nologo --convert-to pdf --outdir $(pwd) input_file \
+    && libreoffice --invisible --headless --nologo --convert-to pdf --outdir $(pwd) input_file >/dev/null 2>&1 \
     # Send converted file to stdout
     && cat input_file.pdf


### PR DESCRIPTION
but with "convert /home/converter/input....."
Brings warnings with ghostscript and printers doesn't recognize PDF-files correctly